### PR TITLE
Various deserialization fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,18 @@ limitations under the License.
 
 ## Release Notes
 
+### v1.1.1
+
+- fixed multiple bugs:
+    - when reading TMX files which did not have the header
+      attribute "srclang", it would put all of the translation
+      variants into the same translation unit
+    - if the srclang attribute does exist and also exists on
+      the translation unit, and they are different, it put the
+      wrong locale onto the translation unit instance
+    - it ignored the adminlang attribute if it was there
+    - it put the wrong datatype onto the translation units
+
 ### v1.1.0
 
 - added new method diff() to return a new TMX instance that contains

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib-tmx",
-    "version": "1.1.0",
+    "version": "1.1.1",
     "main": "./lib/index.js",
     "module": "./src/index.js",
     "exports": {

--- a/src/tmx.js
+++ b/src/tmx.js
@@ -151,6 +151,7 @@ class TMX {
             segtype: "paragraph"
         };
         this.sourceLocale = "en-US";
+        this.adminLocale = this.sourceLocale;
 
         if (options) {
             this.properties = options.properties || this.properties;
@@ -471,7 +472,7 @@ class TMX {
                         segtype: this.properties.segtype,
                         creationtool: this.properties.creationtool || "loctool",
                         creationtoolversion: this.properties.creationtoolversion || getVersion(),
-                        adminlang: "en-US",
+                        adminlang: this.adminLocale,
                         srclang: this.sourceLocale,
                         datatype: this.properties.datatype
                     }
@@ -537,6 +538,9 @@ class TMX {
             if (attrs.srclang) {
                 this.sourceLocale = attrs.srclang;
             }
+            if (attrs.adminlang) {
+                this.adminLocale = attrs.adminlang;
+            }
         }
         if (tmx.body) {
             if (tmx.body.tu) {
@@ -544,9 +548,8 @@ class TMX {
                 for (let i = 0; i < units.length; i++) {
                     const unit = units[i];
                     const tu = new TranslationUnit();
-                    if (unit._attributes & unit._attributes.srclang) {
-                        tu.sourceLocale = unit._attributes.srclang;
-                    }
+                    tu.sourceLocale = (unit._attributes && unit._attributes.srclang) || this.sourceLocale || this.adminLocale || "en";
+                    tu.datatype = this.properties.datatype;
                     if (unit.prop) {
                         const props = makeArray(unit.prop);
                         const properties = {};
@@ -584,7 +587,7 @@ class TMX {
                                     string
                                 });
                                 tu.addVariant(variant);
-                                if (variant.locale === this.sourceLocale) {
+                                if (variant.locale === tu.sourceLocale) {
                                     tu.source = variant.string;
                                     tu.sourceLocale = variant.locale;
                                 }

--- a/test/testTMX.js
+++ b/test/testTMX.js
@@ -1692,6 +1692,188 @@ export const testTMX = {
         test.done();
     },
 
+    testTMXDeserializeUnitsSrclangIsDifferentThanHeaderSrclang: function(test) {
+        test.expect(21);
+
+        const tmx = new TMX();
+
+        const contents = '<?xml version="1.0" encoding="utf-8"?>\n' +
+            '<tmx version="1.4">\n' +
+            '  <header segtype="paragraph" creationtool="loctool" creationtoolversion="2.20.2" srclang="en-US" adminlang="en-US" datatype="javascript"/>\n' +
+            '  <body>\n' +
+            '    <tu srclang="en">\n' +
+            '      <prop type="x-project">webapp</prop>\n' +
+            '      <tuv xml:lang="en">\n' +
+            '        <seg>Asdf asdf</seg>\n' +
+            '      </tuv>\n' +
+            '      <tuv xml:lang="de-DE">\n' +
+            '        <seg>eins zwei drei</seg>\n' +
+            '      </tuv>\n' +
+            '    </tu>\n' +
+            '    <tu srclang="en">\n' +
+            '      <prop type="x-project">webapp</prop>\n' +
+            '      <tuv xml:lang="en">\n' +
+            '        <seg>Foobar</seg>\n' +
+            '      </tuv>\n' +
+            '      <tuv xml:lang="de-DE">\n' +
+            '        <seg>Das Foobar</seg>\n' +
+            '      </tuv>\n' +
+            '    </tu>\n' +
+            '  </body>\n' +
+            '</tmx>';
+
+        tmx.deserialize(contents);
+
+        test.ok(tmx.size(), 1);
+        test.equal(tmx.sourceLocale, "en-US");
+
+        const units = tmx.getTranslationUnits();
+        test.ok(units);
+        test.ok(Array.isArray(units));
+        test.equal(units.length, 2);
+
+        test.equal(units[0].sourceLocale, "en");
+        test.equal(units[1].sourceLocale, "en");
+
+        let variants = units[0].getVariants();
+        test.ok(variants);
+        test.ok(Array.isArray(variants));
+        test.equal(variants.length, 2);
+
+        test.equal(variants[0].string, "Asdf asdf");
+        test.equal(variants[0].locale, "en");
+
+        test.equal(variants[1].string, "eins zwei drei");
+        test.equal(variants[1].locale, "de-DE");
+
+        variants = units[1].getVariants();
+        test.ok(variants);
+        test.ok(Array.isArray(variants));
+        test.equal(variants.length, 2);
+
+        test.equal(variants[0].string, "Foobar");
+        test.equal(variants[0].locale, "en");
+
+        test.equal(variants[1].string, "Das Foobar");
+        test.equal(variants[1].locale, "de-DE");
+
+        test.done();
+    },
+
+    testTMXDeserializeNoSrclangHeaderAttrAtAll: function(test) {
+        test.expect(21);
+
+        const tmx = new TMX();
+
+        const contents = '<?xml version="1.0" encoding="utf-8"?>\n' +
+            '<tmx version="1.4">\n' +
+            '  <header segtype="paragraph" creationtool="loctool" creationtoolversion="2.20.2" adminlang="en-US" datatype="javascript"/>\n' +
+            '  <body>\n' +
+            '    <tu srclang="en">\n' +
+            '      <prop type="x-project">webapp</prop>\n' +
+            '      <tuv xml:lang="en">\n' +
+            '        <seg>Asdf asdf</seg>\n' +
+            '      </tuv>\n' +
+            '      <tuv xml:lang="de-DE">\n' +
+            '        <seg>eins zwei drei</seg>\n' +
+            '      </tuv>\n' +
+            '    </tu>\n' +
+            '    <tu srclang="en">\n' +
+            '      <prop type="x-project">webapp</prop>\n' +
+            '      <tuv xml:lang="en">\n' +
+            '        <seg>Foobar</seg>\n' +
+            '      </tuv>\n' +
+            '      <tuv xml:lang="de-DE">\n' +
+            '        <seg>Das Foobar</seg>\n' +
+            '      </tuv>\n' +
+            '    </tu>\n' +
+            '  </body>\n' +
+            '</tmx>';
+
+        tmx.deserialize(contents);
+
+        test.ok(tmx.size(), 1);
+        test.equal(tmx.sourceLocale, "en-US");
+
+        const units = tmx.getTranslationUnits();
+        test.ok(units);
+        test.ok(Array.isArray(units));
+        test.equal(units.length, 2);
+
+        test.equal(units[0].sourceLocale, "en");
+        test.equal(units[1].sourceLocale, "en");
+
+        let variants = units[0].getVariants();
+        test.ok(variants);
+        test.ok(Array.isArray(variants));
+        test.equal(variants.length, 2);
+
+        test.equal(variants[0].string, "Asdf asdf");
+        test.equal(variants[0].locale, "en");
+
+        test.equal(variants[1].string, "eins zwei drei");
+        test.equal(variants[1].locale, "de-DE");
+
+        variants = units[1].getVariants();
+        test.ok(variants);
+        test.ok(Array.isArray(variants));
+        test.equal(variants.length, 2);
+
+        test.equal(variants[0].string, "Foobar");
+        test.equal(variants[0].locale, "en");
+
+        test.equal(variants[1].string, "Das Foobar");
+        test.equal(variants[1].locale, "de-DE");
+
+        test.done();
+    },
+
+    testTMXDeserializeRightDatatype: function(test) {
+        test.expect(7);
+
+        const tmx = new TMX();
+
+        const contents = '<?xml version="1.0" encoding="utf-8"?>\n' +
+            '<tmx version="1.4">\n' +
+            '  <header segtype="paragraph" creationtool="loctool" creationtoolversion="2.20.2" srclang="en-US" adminlang="en-US" datatype="javascript"/>\n' +
+            '  <body>\n' +
+            '    <tu srclang="en">\n' +
+            '      <prop type="x-project">webapp</prop>\n' +
+            '      <tuv xml:lang="en">\n' +
+            '        <seg>Asdf asdf</seg>\n' +
+            '      </tuv>\n' +
+            '      <tuv xml:lang="de-DE">\n' +
+            '        <seg>eins zwei drei</seg>\n' +
+            '      </tuv>\n' +
+            '    </tu>\n' +
+            '    <tu srclang="en">\n' +
+            '      <prop type="x-project">webapp</prop>\n' +
+            '      <tuv xml:lang="en">\n' +
+            '        <seg>Foobar</seg>\n' +
+            '      </tuv>\n' +
+            '      <tuv xml:lang="de-DE">\n' +
+            '        <seg>Das Foobar</seg>\n' +
+            '      </tuv>\n' +
+            '    </tu>\n' +
+            '  </body>\n' +
+            '</tmx>';
+
+        tmx.deserialize(contents);
+
+        test.ok(tmx.size(), 1);
+        test.equal(tmx.sourceLocale, "en-US");
+
+        const units = tmx.getTranslationUnits();
+        test.ok(units);
+        test.ok(Array.isArray(units));
+        test.equal(units.length, 2);
+
+        test.equal(units[0].datatype, "javascript");
+        test.equal(units[1].datatype, "javascript");
+
+        test.done();
+    },
+
     testTMXDeserializeSimpleTransUnitProperties: function(test) {
         test.expect(6);
 


### PR DESCRIPTION
- fixed multiple bugs:
    - when reading TMX files which did not have the header
      attribute "srclang", it would put all of the translation
      variants into the same translation unit
    - if the srclang attribute does exist and also exists on
      the translation unit, and they are different, it put the
      wrong locale onto the translation unit instance
    - it ignored the adminlang attribute if it was there
    - it put the wrong datatype onto the translation units
